### PR TITLE
Update CSS:

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -1,14 +1,97 @@
 /* Global Styles */
+
+/* inter-100 - latin */
+@font-face {
+  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 100;
+  src: url('../fonts/inter-v13-latin/inter-v13-latin-100.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+}
+/* inter-200 - latin */
+@font-face {
+  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 200;
+  src: url('../fonts/inter-v13-latin/inter-v13-latin-200.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+}
+/* inter-300 - latin */
+@font-face {
+  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 300;
+  src: url('../fonts/inter-v13-latin/inter-v13-latin-300.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+}
+/* inter-regular - latin */
+@font-face {
+  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  src: url('../fonts/inter-v13-latin/inter-v13-latin-regular.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+}
+/* inter-500 - latin */
+@font-face {
+  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 500;
+  src: url('../fonts/inter-v13-latin/inter-v13-latin-500.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+}
+/* inter-600 - latin */
+@font-face {
+  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 600;
+  src: url('../fonts/inter-v13-latin/inter-v13-latin-600.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+}
+/* inter-700 - latin */
+@font-face {
+  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 700;
+  src: url('../fonts/inter-v13-latin/inter-v13-latin-700.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+}
+/* inter-800 - latin */
+@font-face {
+  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 800;
+  src: url('../fonts/inter-v13-latin/inter-v13-latin-800.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+}
+/* inter-900 - latin */
+@font-face {
+  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 900;
+  src: url('../fonts/inter-v13-latin/inter-v13-latin-900.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+}
+
 :root {
   /* COLOURS */
-  --white:  #ebdfdf;
-  --accent-yellow: #da9918;
-  --black: #202020;
+  --white: #fffff0; /* White text color */
+  --accent-color: #da9918; /* Accent color */
+  --black: #202020; /* Black background color */
+  --grey: #333333;
 
   /* BUTTONS*/
   --border-radius: 0.5rem;
   --padding: 0.5rem 1rem;
-  --font-family: ;
+
+  /* Font Family */
+  --font-family: 'Inter';
+
+  /* FONT SIZES */
+  --font-size-base: 0.9rem; /* Base font size */
+  --font-size-h1: 1.75rem; /* Heading 1 size for mobile */
+  --font-size-h2: 1.4rem; /* Heading 2 size for mobile */
+  --font-size-p: 0.9rem; /* Paragraph size for mobile */
 }
 
 /* Reset or Normalize */
@@ -20,34 +103,74 @@
   padding: 0;
 }
 
+body {
+  font-family: var(--font-family);
+  background-color: var(--black);
+  color: var(--white);
+  font-size: var(--font-size-base);
+  line-height: 1.55;
+}
+
+/* Typography */
 h1 {
-  font-size: 2.3rem;
+  font-size: var(--font-size-h1);
   color: var(--white);
 }
 
 h2 {
-  font-size: 2rem;
+  font-size: var(--font-size-h2);
   color: var(--white);
 }
 
 p {
+  font-size: var(--font-size-p);
   color: var(--white);
 }
 
 a {
   text-decoration: none;
+  color: var(--primary-color);
 }
 
+ul li {
+  font-size: var(--font-size-p);
+  color: var(--white);
+}
 /* Component Styles */
 button {
   padding: var(--padding);
   color: var(--white);
-  background-color: var(--accent-yellow);
+  background-color: var(--accent-color);
   border: none;
   border-radius: var(--border-radius);
   cursor: pointer;
 }
 
 button:hover {
-  background-color: darken(var(--primary-color), 10%);
+  background-color: darken(var(--accent-color), 10%);
+}
+
+/* Responsive Typography Adjustments */
+@media (min-width: 576px) {
+  :root {
+    --font-size-h1: 2.25rem;
+    --font-size-h2: 2rem;
+    --font-size-p: 1.125rem;
+  }
+}
+
+@media (min-width: 768px) {
+  :root {
+    --font-size-h1: 2.5rem;
+    --font-size-h2: 2.25rem;
+    --font-size-p: 1.25rem;
+  }
+}
+
+@media (min-width: 992px) {
+  :root {
+    --font-size-h1: 3rem;
+    --font-size-h2: 2.5rem;
+    --font-size-p: 1.5rem;
+  }
 }


### PR DESCRIPTION
- Adjusted color variables to use white for text and black for background.
- Renamed accent-yellow to accent-color.
- Added @font-face for custom font 'Inter'.

Adjusted font sizes for mobile-first design:
- Base font size: 0.9rem
- H1: 1.75rem
- H2: 1.4rem
- Paragraph: 0.9rem Ensured the --font-family variable is set and used it in the body.

CSS is now ready for mobile-first layout and uses custom font 'Inter'.